### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/furimas_controller.rb
+++ b/app/controllers/furimas_controller.rb
@@ -1,5 +1,5 @@
 class FurimasController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -16,6 +16,10 @@ class FurimasController < ApplicationController
     else
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/views/furimas/index.html.erb
+++ b/app/views/furimas/index.html.erb
@@ -132,7 +132,7 @@
         <ul class='item-lists'>
           <% @items.each do |item| %>
             <li class='list'>
-              <%= link_to '#' do %>
+              <%= link_to furima_path(item) do %>
                 <%= image_tag url_for(item.image), class: "item-img" %>
                 <div class='item-info'>
                   <h3 class='item-name'>

--- a/app/views/furimas/show.html.erb
+++ b/app/views/furimas/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image, class: "item-box-img" %>
@@ -16,10 +16,10 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.item_price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= Itemshippingfeestatus.find(@item.item_shipping_fee_status_id).name %>
       </span>
     </div>
 

--- a/app/views/furimas/show.html.erb
+++ b/app/views/furimas/show.html.erb
@@ -7,7 +7,7 @@
       <%= "商品名" %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image, class: "item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -23,48 +23,59 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <% end %>
 
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? && current_user.id != @item.user_id %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.item_info %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value">
+            <%= @item.user.nickname %>
+          </td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value">
+            <%= Genre.find(@item.item_category_id).name %>
+          </td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value">
+            <%= Itemsalesstatus.find(@item.item_sales_status_id).name %>
+          </td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value">
+            <%= Itemshippingfeestatus.find(@item.item_shipping_fee_status_id).name %>
+          </td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value">
+            <%= Prefecture.find(@item.prefecture_id).name %>
+          </td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value">
+            <%= Itemscheduleddelivery.find(@item.item_scheduled_delivery_id).name %>
+          </td>
         </tr>
       </tbody>
     </table>

--- a/app/views/furimas/show.html.erb
+++ b/app/views/furimas/show.html.erb
@@ -114,9 +114,8 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item">
+  <%= Genre.find(@item.item_category_id).name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
 
   root to:"furimas#index"
-  resources :furimas, only: [:new, :create]
+  resources :furimas, only: [:index, :new, :create, :show]
   resources :users
 end


### PR DESCRIPTION
# What
商品詳細表示機能の実装
# Why
詳細表示機能に伴う各種機能の実装

- 商品詳細表示ページは、ログイン状況や商品の販売状況に関係なく、誰でも見ることができること。
- 商品一覧ページにて商品情報をクリックすると、該当する商品の商品詳細表示ページへ遷移すること。
- 商品出品時に登録した情報（商品名・商品画像・価格・配送料の負担・商品の説明・出品者名・カテゴリー・商品の状態・発送元の地域・発送日の目安）が、見本アプリと同様の形で表示されること。
- 画像が表示されており、画像がリンク切れなどにならないこと。
- ログイン状態且つ、自身が出品した販売中商品の場合にのみ、「商品の編集」「削除」ボタンが表示されること。
- ログイン状態且つ、自身が出品していない販売中商品の場合にのみ、「購入画面に進む」ボタンが表示されること。
- ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されないこと。
- ログアウト状態の場合は、商品の販売状況に関わらず、「商品の編集」「削除」「購入画面に進む」ボタンが表示されないこと。

※以下の機能は商品購入機能実装時に実装予定です。
- 売却済みの商品は、画像上に「sold out」の文字が表示されること。

# ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
![login_myitem](https://github.com/Rui-Tanizaki/furima-40276/assets/155947121/659c6bb8-7c00-4aad-a207-eeb4ffb92265)

# ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
![login_otheritem](https://github.com/Rui-Tanizaki/furima-40276/assets/155947121/4a6a6809-f538-4583-b364-56042430d79f)

# ログアウト状態で、商品詳細ページへ遷移した動画
![logout_item](https://github.com/Rui-Tanizaki/furima-40276/assets/155947121/816f33ad-d0ae-41a5-bc28-e01d3df969ca)
