### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/furimas_controller.rb
+++ b/app/controllers/furimas_controller.rb
@@ -1,6 +1,6 @@
 class FurimasController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:edit, :update]
+  before_action :set_item, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -38,6 +38,18 @@ class FurimasController < ApplicationController
       redirect_to furima_path(@item)
     else
       render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if current_user != @item.user
+      redirect_to root_path
+    else
+      if @item.destroy
+        redirect_to root_path
+      else
+        redirect_to root_path
+      end
     end
   end
 

--- a/app/controllers/furimas_controller.rb
+++ b/app/controllers/furimas_controller.rb
@@ -45,11 +45,8 @@ class FurimasController < ApplicationController
     if current_user != @item.user
       redirect_to root_path
     else
-      if @item.destroy
-        redirect_to root_path
-      else
-        redirect_to root_path
-      end
+      @item.destroy
+      redirect_to root_path
     end
   end
 

--- a/app/views/furimas/show.html.erb
+++ b/app/views/furimas/show.html.erb
@@ -27,7 +27,7 @@
 
       <%= link_to "商品の編集", edit_furima_path(@item), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <%= link_to "削除", furima_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
     <% end %>
 
     <% if user_signed_in? && current_user.id != @item.user_id %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
 
   root to:"furimas#index"
-  resources :furimas, only: [:index, :new, :create, :show, :edit,:update]
+  resources :furimas, only: [:index, :new, :create, :show, :edit,:update,:destroy]
   resources :users
 end


### PR DESCRIPTION
# What
商品削除機能の実装

# Why
商品削除機能の追加に伴う機能の実装
実装した機能は以下となります。

-  ログイン状態の場合にのみ、自身が出品した商品情報を削除できること。
-  削除が完了したら、トップページに遷移すること。

# ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
![itemdelete](https://github.com/Rui-Tanizaki/furima-40276/assets/155947121/0fbccbcd-366a-459d-90c7-808f172bc9a7)
